### PR TITLE
Use current query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MODULES = pgl_ddl_deploy
 REGRESS := 01_create_ext 02_setup 03_add_configs 04_deploy \
            05_allowed 06_multi 07_edges 08_ignored \
            09_unsupported 10_no_create_user 11_override \
-           12_sql_command_tags 99_cleanup
+           12_sql_command_tags 13_transaction 99_cleanup
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS) 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Transparent DDL replication for Postgres 9.5+
 [Limitations and Restrictions](#limitations)
 - [DDL involving multiple tables](#multi_tables)
 - [Unsupported Commands](#unsupported)
-- [`track_activity_query_size` Limitations](#activity)
 - [Multi-Statement Client SQL Limitations](#multi_statement)
 
 [Resolving DDL Replication Issues](#resolve)
@@ -444,16 +443,6 @@ the `INSERT` will be replicated by normal pglogical replication.
 
 **NOTE** that temp tables are not affected by this limitation, since temp objects are
 always excluded from DDL replication anyway.
-
-To resolve these, see [Resolving Unhandled DDL](#resolve_unhandled).
-
-## <a name="activity"></a>`track_activity_query_size` Limitations
-
-If your DDL statement exceeds the length of `track_activity_query_size`, an
-unhandled exception will be logged.  It is recommended to run higher settings
-(10-15k for example) for `track_activity_query_size` to use this framework
-effectively.  For consideration: Postgres should have a project to make the C
-`query_string` available within event triggers.
 
 To resolve these, see [Resolving Unhandled DDL](#resolve_unhandled).
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ data.
 ## <a name="installation"></a>Installation
 
 The functionality of this requires postgres version 9.5+ and a working install
-of pglogical.  Packages will be available soon.  To build from source:
+of pglogical 1.* (working on 2.* compatibility).  Packages will be available
+soon.  To build from source:
 ```
 make
 make install

--- a/expected/05_allowed.out
+++ b/expected/05_allowed.out
@@ -581,8 +581,8 @@ SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY i
 (10 rows)
 
 SELECT * FROM pgl_ddl_deploy.unhandled;
- id | set_name | pid | executed_at | ddl_sql_raw | command_tag | reason | backend_xmin 
-----+----------+-----+-------------+-------------+-------------+--------+--------------
+ id | set_name | pid | executed_at | ddl_sql_raw | command_tag | reason | txid 
+----+----------+-----+-------------+-------------+-------------+--------+------
 (0 rows)
 
 SELECT * FROM pgl_ddl_deploy.exceptions;

--- a/expected/13_transaction.out
+++ b/expected/13_transaction.out
@@ -1,0 +1,162 @@
+SET ROLE test_pgl_ddl_deploy;
+SET client_min_messages TO warning;
+BEGIN;
+/***
+In default schema
+**/
+CREATE TABLE foo(id serial primary key);
+SELECT * FROM check_rep_tables;
+ set_name | table_name 
+----------+------------
+ test1    | foo
+ test2    | foo
+ test3    | foo
+ test4    | foo
+(4 rows)
+
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+ set_name |               ddl_sql_raw                |               ddl_sql_sent               
+----------+------------------------------------------+------------------------------------------
+ test4    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+ test3    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+ test2    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+ test1    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+ test8    | DROP TABLE foobar.foo;                   | DROP TABLE foobar.foo;
+ test7    | DROP TABLE foobar.foo;                   | DROP TABLE foobar.foo;
+ test6    | DROP TABLE foobar.foo;                   | DROP TABLE foobar.foo;
+ test5    | DROP TABLE foobar.foo;                   | DROP TABLE foobar.foo;
+ test4    | DROP TABLE foobar.foo;                   | DROP TABLE foobar.foo;
+ test3    | DROP TABLE foobar.foo;                   | DROP TABLE foobar.foo;
+(10 rows)
+
+ALTER TABLE foo ADD COLUMN bla TEXT;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+ set_name |               ddl_sql_raw                |               ddl_sql_sent               
+----------+------------------------------------------+------------------------------------------
+ test4    | ALTER TABLE foo ADD COLUMN bla TEXT;     | ALTER TABLE foo ADD COLUMN bla TEXT;
+ test3    | ALTER TABLE foo ADD COLUMN bla TEXT;     | ALTER TABLE foo ADD COLUMN bla TEXT;
+ test2    | ALTER TABLE foo ADD COLUMN bla TEXT;     | ALTER TABLE foo ADD COLUMN bla TEXT;
+ test1    | ALTER TABLE foo ADD COLUMN bla TEXT;     | ALTER TABLE foo ADD COLUMN bla TEXT;
+ test4    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+ test3    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+ test2    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+ test1    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+ test8    | DROP TABLE foobar.foo;                   | DROP TABLE foobar.foo;
+ test7    | DROP TABLE foobar.foo;                   | DROP TABLE foobar.foo;
+(10 rows)
+
+INSERT INTO foo (bla) VALUES (1),(2),(3);
+DROP TABLE foo CASCADE;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+ set_name |               ddl_sql_raw                |               ddl_sql_sent               
+----------+------------------------------------------+------------------------------------------
+ test4    | DROP TABLE foo CASCADE;                  | DROP TABLE foo CASCADE;
+ test3    | DROP TABLE foo CASCADE;                  | DROP TABLE foo CASCADE;
+ test2    | DROP TABLE foo CASCADE;                  | DROP TABLE foo CASCADE;
+ test1    | DROP TABLE foo CASCADE;                  | DROP TABLE foo CASCADE;
+ test4    | ALTER TABLE foo ADD COLUMN bla TEXT;     | ALTER TABLE foo ADD COLUMN bla TEXT;
+ test3    | ALTER TABLE foo ADD COLUMN bla TEXT;     | ALTER TABLE foo ADD COLUMN bla TEXT;
+ test2    | ALTER TABLE foo ADD COLUMN bla TEXT;     | ALTER TABLE foo ADD COLUMN bla TEXT;
+ test1    | ALTER TABLE foo ADD COLUMN bla TEXT;     | ALTER TABLE foo ADD COLUMN bla TEXT;
+ test4    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+ test3    | /***                                    +| /***                                    +
+          | In default schema                       +| In default schema                       +
+          | **/                                     +| **/                                     +
+          | CREATE TABLE foo(id serial primary key); | CREATE TABLE foo(id serial primary key);
+(10 rows)
+
+CREATE TABLE foobar.foo(id serial primary key);
+SELECT * FROM check_rep_tables;
+ set_name | table_name 
+----------+------------
+ test1    | foobar.foo
+ test2    | foobar.foo
+ test3    | foobar.foo
+ test4    | foobar.foo
+ test5    | foobar.foo
+ test6    | foobar.foo
+ test7    | foobar.foo
+ test8    | foobar.foo
+(8 rows)
+
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+ set_name |                   ddl_sql_raw                   |                  ddl_sql_sent                   
+----------+-------------------------------------------------+-------------------------------------------------
+ test8    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+ test7    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+ test6    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+ test5    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+ test4    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+ test3    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+ test2    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+ test1    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+ test4    | DROP TABLE foo CASCADE;                         | DROP TABLE foo CASCADE;
+ test3    | DROP TABLE foo CASCADE;                         | DROP TABLE foo CASCADE;
+(10 rows)
+
+ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+ set_name |                   ddl_sql_raw                   |                  ddl_sql_sent                   
+----------+-------------------------------------------------+-------------------------------------------------
+ test8    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;     | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+ test7    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;     | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+ test6    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;     | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+ test5    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;     | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+ test4    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;     | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+ test3    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;     | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+ test2    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;     | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+ test1    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;     | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+ test8    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+ test7    | CREATE TABLE foobar.foo(id serial primary key); | CREATE TABLE foobar.foo(id serial primary key);
+(10 rows)
+
+INSERT INTO foobar.foo (bla) VALUES (1),(2),(3);
+DROP TABLE foobar.foo CASCADE;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+ set_name |                 ddl_sql_raw                 |                ddl_sql_sent                 
+----------+---------------------------------------------+---------------------------------------------
+ test8    | DROP TABLE foobar.foo CASCADE;              | DROP TABLE foobar.foo CASCADE;
+ test7    | DROP TABLE foobar.foo CASCADE;              | DROP TABLE foobar.foo CASCADE;
+ test6    | DROP TABLE foobar.foo CASCADE;              | DROP TABLE foobar.foo CASCADE;
+ test5    | DROP TABLE foobar.foo CASCADE;              | DROP TABLE foobar.foo CASCADE;
+ test4    | DROP TABLE foobar.foo CASCADE;              | DROP TABLE foobar.foo CASCADE;
+ test3    | DROP TABLE foobar.foo CASCADE;              | DROP TABLE foobar.foo CASCADE;
+ test2    | DROP TABLE foobar.foo CASCADE;              | DROP TABLE foobar.foo CASCADE;
+ test1    | DROP TABLE foobar.foo CASCADE;              | DROP TABLE foobar.foo CASCADE;
+ test8    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT; | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+ test7    | ALTER TABLE foobar.foo ADD COLUMN bla TEXT; | ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+(10 rows)
+
+COMMIT;
+SELECT * FROM pgl_ddl_deploy.exceptions;
+ id | set_name | pid | executed_at | ddl_sql | err_msg | err_state 
+----+----------+-----+-------------+---------+---------+-----------
+(0 rows)
+

--- a/sql/13_transaction.sql
+++ b/sql/13_transaction.sql
@@ -1,0 +1,35 @@
+SET ROLE test_pgl_ddl_deploy;
+SET client_min_messages TO warning;
+
+BEGIN;
+
+/***
+In default schema
+**/
+CREATE TABLE foo(id serial primary key);
+SELECT * FROM check_rep_tables;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+
+ALTER TABLE foo ADD COLUMN bla TEXT;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+
+INSERT INTO foo (bla) VALUES (1),(2),(3);
+
+DROP TABLE foo CASCADE;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+
+CREATE TABLE foobar.foo(id serial primary key);
+SELECT * FROM check_rep_tables;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+
+ALTER TABLE foobar.foo ADD COLUMN bla TEXT;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+
+INSERT INTO foobar.foo (bla) VALUES (1),(2),(3);
+
+DROP TABLE foobar.foo CASCADE;
+SELECT set_name, ddl_sql_raw, ddl_sql_sent FROM pgl_ddl_deploy.events ORDER BY id DESC LIMIT 10;
+
+COMMIT;
+
+SELECT * FROM pgl_ddl_deploy.exceptions;


### PR DESCRIPTION
As suggested by [Craig Ringer](https://github.com/ringerc).  This is much better because is not dependent upon `track_activity_query_size`, and requires no special permissions.  Also, `txid` is better to use than `backend_xmin`.

Also, I've noted in the docs that currently, this only works with pglogical 1.*.  It should be easy to make amends to work with 2 as well, but that will be another PR.

Passing:
```
jfinzel@pgdev01:/usr/src/pgl_ddl_deploy$ PGPORT=5639 make installcheck
/usr/lib/postgresql/9.6dev/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/lib/postgresql/9.6dev/bin'    --dbname=contrib_regression 01_create_ext 02_setup 03_add_configs 04_deploy 05_allowed 06_multi 07_edges 08_ignored 09_unsupported 10_no_create_user 11_override 12_sql_command_tags 13_transaction 99_cleanup
(using postmaster on Unix socket, port 5639)
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test 01_create_ext            ... ok
test 02_setup                 ... ok
test 03_add_configs           ... ok
test 04_deploy                ... ok
test 05_allowed               ... ok
test 06_multi                 ... ok
test 07_edges                 ... ok
test 08_ignored               ... ok
test 09_unsupported           ... ok
test 10_no_create_user        ... ok
test 11_override              ... ok
test 12_sql_command_tags      ... ok
test 13_transaction           ... ok
test 99_cleanup               ... ok

======================
 All 14 tests passed.
======================
```