### PR TITLE
Debian package version bump, v1.3.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pgl-ddl-deploy (1.3.0-1) unstable; urgency=medium
+
+  * Version 1.3.0 from upstream.
+
+ -- Dominic Salvador <dsalvador@enova.com>  Tue, 17 Apr 2018 14:04:55 -0500
+
 pgl-ddl-deploy (1.2.0-1) unstable; urgency=medium
 
   * Version 1.2.0 from upstream.


### PR DESCRIPTION
The Debian changelog must be updated when a new version of the source is released.