### PR TITLE
Add Debian watch file

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,2 @@
+version=4
+https://github.com/enova/pgl_ddl_deploy/releases .*/v(.*).tar.gz


### PR DESCRIPTION
Watch files are used by packagers and the Debian infrastructure to scan for new upstream versions (via uscan).