### PR TITLE
debian/watch: Tweak to ignore erroneous v.1.5.0 tag

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://github.com/enova/pgl_ddl_deploy/releases .*/v(.*).tar.gz
+https://github.com/enova/pgl_ddl_deploy/releases .*/v([0-9].*).tar.gz


### PR DESCRIPTION
At the moment, uscan thinks the newest version was `.1.5.0`:
```
$ uscan --verbose
...
uscan info: Found the following matching hrefs on the web page (newest first):
   /enova/pgl_ddl_deploy/archive/v.1.5.0.tar.gz (.1.5.0) index=.1.5.0-1 
   /enova/pgl_ddl_deploy/archive/v1.5.1.tar.gz (1.5.1) index=1.5.1-1 
   /enova/pgl_ddl_deploy/archive/v1.4.0.tar.gz (1.4.0) index=1.4.0-1 
   /enova/pgl_ddl_deploy/archive/v1.3.0.tar.gz (1.3.0) index=1.3.0-1 
uscan info: Looking at $base = https://github.com/enova/pgl_ddl_deploy/releases with
    $filepattern = .*/v(.*).tar.gz found
    $newfile     = /enova/pgl_ddl_deploy/archive/v.1.5.0.tar.gz
    $newversion  = .1.5.0 which is newer than
    $lastversion = 1.5.1
```

Please consider either merging this, or deleting the erroneous tag, and tagging 1.5.0 correctly. Thanks!
