### PR TITLE
Fix tests of 2.x upload to Debian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
-pgl-ddl-deploy (2.0.0-1) unstable; urgency=medium
+pgl-ddl-deploy (2.0.0-2) unstable; urgency=medium
 
+  [ Jeremy Finzel ]
   * Regression fix - add -o wal_level=logical
 
- -- Jeremy Finzel <jfinzel@enova.com>  Thu, 19 Nov 2020 07:46:13 -0600
+  [ Christian Ehrhardt ]
+  * d/changelog: fix new version to be >2.0.0-1
+  * revert unmentioned drop of needs-root in d/t/control
+  * d/t/control: update test dependencies for postgresql-13
+
+ -- Christian Ehrhardt <christian.ehrhardt@canonical.com>  Mon, 07 Dec 2020 14:18:20 +0100
 
 pgl-ddl-deploy (2.0.0-1) unstable; urgency=medium
 

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,4 +1,4 @@
 # requires user "postgres", so run as root
-Depends: @, postgresql-server-dev-all
+Depends: @, postgresql-server-dev-all, postgresql-contrib, postgresql-13-pglogical
 Tests: installcheck
 Restrictions: allow-stderr, needs-root


### PR DESCRIPTION
Hi,
I've found all the tests to be broken in 2.x
https://autopkgtest.ubuntu.com/packages/p/pgl-ddl-deploy/hirsute/amd64
Example:
https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-hirsute/hirsute/amd64/p/pgl-ddl-deploy/20201207_103315_1341d@/log.gz
The same happened on all architectures.

When looking into it I found it was a collection of semi-trivial things that would help to get pgl-ddl-deploy running (and thereby also unblock pglogical) going again.

Overall we have three fixes:
- the last upload silently dropped d/t/control needs-root but it is required. Git is actually good on that, but the last upload was not
- the wal level fix is good, but it duplicated the version number and therefore isn't active yet
- and finally the only real change, which is updating the test dependencies as done by pg_buildext

