### PR TITLE
fix invalid n

### DIFF
--- a/expected/53_1_5_features.out
+++ b/expected/53_1_5_features.out
@@ -255,7 +255,7 @@ TABLE public.foo;
 Try cancel_then_terminate, which should first try to cancel
 ****/
 -- This process should be killed
-\! echo "BEGIN; SELECT * FROM public.foo;\n\! sleep 15" | psql contrib_regression > /dev/null 2>&1 &
+\! echo "BEGIN; SELECT * FROM public.foo;\! sleep 15" | psql contrib_regression > /dev/null 2>&1 &
 -- This process should not be killed
 \! psql contrib_regression -c "BEGIN; INSERT INTO public.bar (bla) VALUES (1); SELECT pg_sleep(5); COMMIT;" > /dev/null 2>&1 &
 SELECT pg_sleep(1);

--- a/sql/53_1_5_features.sql
+++ b/sql/53_1_5_features.sql
@@ -144,7 +144,7 @@ TABLE public.foo;
 Try cancel_then_terminate, which should first try to cancel
 ****/
 -- This process should be killed
-\! echo "BEGIN; SELECT * FROM public.foo;\n\! sleep 15" | psql contrib_regression > /dev/null 2>&1 &
+\! echo "BEGIN; SELECT * FROM public.foo;\! sleep 15" | psql contrib_regression > /dev/null 2>&1 &
 
 -- This process should not be killed
 \! psql contrib_regression -c "BEGIN; INSERT INTO public.bar (bla) VALUES (1); SELECT pg_sleep(5); COMMIT;" > /dev/null 2>&1 &


### PR DESCRIPTION
It seems there is a different behaviour of function `system` in different glibc versions. Some of them skip/remove `\n` in 
```\! echo "BEGIN; SELECT * FROM public.foo;\n\! sleep 15"
```

Others leave `\n` and we get an error (see `exec_command` in `src/bin/psql/command.c`
```
invalid command \n
```