### PR TITLE
v18+ fixes and compiler warning fix

### DIFF
--- a/ddl_deparse.c
+++ b/ddl_deparse.c
@@ -107,7 +107,7 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 				strtype = "ADD OIDS (and recurse)";
 				break;
 #endif
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= 120000 && PG_VERSION_NUM < 180000
 			case AT_CheckNotNull:
 				strtype = "CHECK NOT NULL";
 				break;

--- a/pgl_ddl_deploy.c
+++ b/pgl_ddl_deploy.c
@@ -11,7 +11,7 @@ PG_FUNCTION_INFO_V1(pgl_ddl_deploy_current_query);
 PG_FUNCTION_INFO_V1(sql_command_tags);
 
 /* Our own version of debug_query_string - see below */
-const char *pgl_ddl_deploy_debug_query_string;
+static const char *pgl_ddl_deploy_debug_query_string;
 
 /*
  * A near-copy of the current_query postgres function which caches the value, ignoring


### PR DESCRIPTION
  PG 18 and 19 fixes & fix compiler warning
  ==================================
    
    * AT_CheckNotNull was silently merged into AT_SetNotNull as of PostgreSQL 18
      (commit 14e87ffa0f, "Make NOT NULL constraints implicit from column
      definition proper constraints").  The existing guard only excluded PG < 12,
      so the case label compiled against PG 12–17 but broke on PG 18+ with:
    
          error: use of undeclared identifier 'AT_CheckNotNull'
          error: duplicate case value 'AT_SetNotNull'
    
      Narrow the guard to PG 12–17 only: >= 120000 && < 180000.
    
    Affected versions: PG 18, PG 19 (and any future major release)
    Fix: tighten the preprocessor guard on AT_CheckNotNull in ddl_deparse.c

    * pgl_ddl_deploy_debug_query_string is used exclusively within
      pgl_ddl_deploy.c and was never intended to be exported.  Declaring
      it without 'static' triggers -Wmissing-variable-declarations, which
      is enabled in PostgreSQL's default CFLAGS and treated as a warning
      (not an error) but is noisy and wrong on principle.
    
      Mark the variable 'static' to give it internal linkage, matching its
      actual usage and silencing the warning cleanly.
    
    Coded by Claude, tested by me.



Per https://github.com/pgdg-packaging/pgdg-rpms/issues/213